### PR TITLE
Add undo and redo for Kanban actions

### DIFF
--- a/src/DragDropApp.tsx
+++ b/src/DragDropApp.tsx
@@ -19,6 +19,7 @@ import {
   updateEntity,
 } from './dnd/util/data';
 import { getBoardModifiers } from './helpers/boardModifiers';
+import { t } from './lang/helpers';
 import KanbanPlugin from './main';
 import { frontmatterKey } from './parsers/common';
 import {
@@ -109,7 +110,9 @@ export function DragDropApp({ win, plugin }: { win: Window; plugin: KanbanPlugin
           dropPath.push(0);
         }
 
-        return stateManager.setState((board) => {
+        const label = dragEntityData.type === DataTypes.Lane ? t('Move list') : t('Move card');
+
+        return plugin.undoManager.run(label, stateManager, (board) => {
           const entity = getEntityFromPath(board, dragPath);
           const newBoard: Board = moveEntity(
             board,
@@ -186,6 +189,9 @@ export function DragDropApp({ win, plugin }: { win: Window; plugin: KanbanPlugin
       const sourceStateManager = plugin.stateManagers.get(sourceView.file);
       const destinationView = plugin.getKanbanView(dropEntity.scopeId, dropEntityData.win);
       const destinationStateManager = plugin.stateManagers.get(destinationView.file);
+      const label = dragEntityData.type === DataTypes.Lane ? t('Move list') : t('Move card');
+      const sourceBefore = plugin.undoManager.capture(sourceStateManager);
+      const destinationBefore = plugin.undoManager.capture(destinationStateManager);
 
       sourceStateManager.setState((sourceBoard) => {
         const entity = getEntityFromPath(sourceBoard, dragPath);
@@ -255,6 +261,8 @@ export function DragDropApp({ win, plugin }: { win: Window; plugin: KanbanPlugin
           return removeEntity(sourceBoard, dragPath, replacementEntity);
         }
       });
+
+      plugin.undoManager.record(label, [sourceBefore, destinationBefore]);
     },
     [views]
   );

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -61,6 +61,7 @@ export interface KanbanSettings {
   'date-picker-week-start'?: number;
   'date-time-display-format'?: string;
   'date-trigger'?: string;
+  'enable-undo'?: boolean;
   'full-list-lane-width'?: boolean;
   'hide-card-count'?: boolean;
   'inline-metadata-position'?: 'body' | 'footer' | 'metadata-table';
@@ -80,6 +81,7 @@ export interface KanbanSettings {
   'show-archive-all'?: boolean;
   'show-board-settings'?: boolean;
   'show-checkboxes'?: boolean;
+  'show-undo-notice'?: boolean;
   'show-relative-date'?: boolean;
   'show-search'?: boolean;
   'show-set-view'?: boolean;
@@ -109,6 +111,7 @@ export const settingKeyLookup: Set<keyof KanbanSettings> = new Set([
   'date-picker-week-start',
   'date-time-display-format',
   'date-trigger',
+  'enable-undo',
   'full-list-lane-width',
   'hide-card-count',
   'inline-metadata-position',
@@ -128,6 +131,7 @@ export const settingKeyLookup: Set<keyof KanbanSettings> = new Set([
   'show-archive-all',
   'show-board-settings',
   'show-checkboxes',
+  'show-undo-notice',
   'show-relative-date',
   'show-search',
   'show-set-view',
@@ -268,6 +272,94 @@ export class SettingsManager {
             },
           });
         });
+      });
+
+    new Setting(contentEl)
+      .setName(t('Enable undo'))
+      .setDesc(t('When toggled, archive, move, and delete actions can be undone from Kanban.'))
+      .then((setting) => {
+        let toggleComponent: ToggleComponent;
+
+        setting
+          .addToggle((toggle) => {
+            toggleComponent = toggle;
+
+            const [value, globalValue] = this.getSetting('enable-undo', local);
+
+            if (value !== undefined) {
+              toggle.setValue(value as boolean);
+            } else if (globalValue !== undefined) {
+              toggle.setValue(globalValue as boolean);
+            } else {
+              toggle.setValue(true);
+            }
+
+            toggle.onChange((newValue) => {
+              this.applySettingsUpdate({
+                'enable-undo': {
+                  $set: newValue,
+                },
+              });
+            });
+          })
+          .addExtraButton((b) => {
+            b.setIcon('lucide-rotate-ccw')
+              .setTooltip(t('Reset to default'))
+              .onClick(() => {
+                const [, globalValue] = this.getSetting('enable-undo', local);
+                toggleComponent.setValue((globalValue as boolean | undefined) ?? true);
+
+                this.applySettingsUpdate({
+                  $unset: ['enable-undo'],
+                });
+              });
+          });
+      });
+
+    new Setting(contentEl)
+      .setName(t('Show undo notice'))
+      .setDesc(
+        t(
+          'Shows a small undo chip after undoable actions. This can be convenient, but it may get in the way; undo is still available from the command palette and keyboard shortcut when this is off.'
+        )
+      )
+      .then((setting) => {
+        let toggleComponent: ToggleComponent;
+
+        setting
+          .addToggle((toggle) => {
+            toggleComponent = toggle;
+
+            const [value, globalValue] = this.getSetting('show-undo-notice', local);
+
+            if (value !== undefined) {
+              toggle.setValue(value as boolean);
+            } else if (globalValue !== undefined) {
+              toggle.setValue(globalValue as boolean);
+            } else {
+              toggle.setValue(false);
+            }
+
+            toggle.onChange((newValue) => {
+              this.applySettingsUpdate({
+                'show-undo-notice': {
+                  $set: newValue,
+                },
+              });
+            });
+          })
+          .addExtraButton((b) => {
+            b.setIcon('lucide-rotate-ccw')
+              .setTooltip(t('Reset to default'))
+              .onClick(() => {
+                const [, globalValue] = this.getSetting('show-undo-notice', local);
+                toggleComponent.setValue((globalValue as boolean | undefined) ?? false);
+
+                this.applySettingsUpdate({
+                  $unset: ['show-undo-notice'],
+                });
+              });
+          });
       });
 
     new Setting(contentEl)

--- a/src/StateManager.ts
+++ b/src/StateManager.ts
@@ -4,8 +4,10 @@ import { useEffect, useState } from 'preact/compat';
 
 import { KanbanView } from './KanbanView';
 import { KanbanSettings, SettingRetrievers } from './Settings';
+import type { KanbanUndoManager } from './UndoManager';
 import { getDefaultDateFormat, getDefaultTimeFormat } from './components/helpers';
 import { Board, BoardTemplate, Item } from './components/types';
+import { t } from './lang/helpers';
 import { ListFormat } from './parsers/List';
 import { BaseFormat, frontmatterKey, shouldRefreshBoard } from './parsers/common';
 import { getTaskStatusDone } from './parsers/helpers/inlineMetadata';
@@ -32,7 +34,8 @@ export class StateManager {
     initialView: KanbanView,
     initialData: string,
     onEmpty: () => void,
-    getGlobalSettings: () => KanbanSettings
+    getGlobalSettings: () => KanbanSettings,
+    public undoManager?: KanbanUndoManager
   ) {
     this.app = app;
     this.file = initialView.file;
@@ -236,6 +239,7 @@ export class StateManager {
       'date-display-format': dateDisplayFormat,
       'date-time-display-format': dateDisplayFormat + ' ' + timeFormat,
       'date-trigger': this.getSettingRaw('date-trigger', suppliedSettings) || defaultDateTrigger,
+      'enable-undo': this.getSettingRaw('enable-undo', suppliedSettings) ?? true,
       'inline-metadata-position':
         this.getSettingRaw('inline-metadata-position', suppliedSettings) || defaultMetadataPosition,
       'time-format': timeFormat,
@@ -254,6 +258,7 @@ export class StateManager {
       'show-board-settings': this.getSettingRaw('show-board-settings', suppliedSettings) ?? true,
       'show-search': this.getSettingRaw('show-search', suppliedSettings) ?? true,
       'show-set-view': this.getSettingRaw('show-set-view', suppliedSettings) ?? true,
+      'show-undo-notice': this.getSettingRaw('show-undo-notice', suppliedSettings) ?? false,
       'tag-colors': this.getSettingRaw('tag-colors', suppliedSettings) ?? [],
       'tag-sort': this.getSettingRaw('tag-sort', suppliedSettings) ?? [],
       'date-colors': this.getSettingRaw('date-colors', suppliedSettings) ?? [],
@@ -364,6 +369,7 @@ export class StateManager {
 
   async archiveCompletedCards() {
     const board = this.state;
+    const before = this.undoManager?.capture(this);
 
     const archived: Item[] = [];
     const shouldAppendArchiveDate = !!this.getSetting('archive-with-date');
@@ -415,6 +421,9 @@ export class StateManager {
           },
         })
       );
+      if (before) {
+        this.undoManager?.record(t('Archive completed cards'), [before]);
+      }
     } catch (e) {
       this.setError(e);
     }

--- a/src/UndoManager.ts
+++ b/src/UndoManager.ts
@@ -14,15 +14,17 @@ interface UndoFileState {
   file: TFile;
   before: Board;
   beforeMd: string;
+  beforeViewStates: ViewStateSnapshot[];
+  after: Board;
   afterMd: string;
-  viewStates: ViewStateSnapshot[];
+  afterViewStates: ViewStateSnapshot[];
 }
 
 interface PendingFileState {
   manager: StateManager;
   before: Board;
   beforeMd: string;
-  viewStates: ViewStateSnapshot[];
+  beforeViewStates: ViewStateSnapshot[];
 }
 
 interface UndoEntry {
@@ -32,6 +34,7 @@ interface UndoEntry {
 }
 
 type BoardUpdater = Board | ((board: Board) => Board);
+type RestoreTarget = 'before' | 'after';
 
 function cloneViewState(state: KanbanViewSettings): KanbanViewSettings {
   const next = { ...state };
@@ -45,6 +48,7 @@ function cloneViewState(state: KanbanViewSettings): KanbanViewSettings {
 
 export class KanbanUndoManager {
   private stack: UndoEntry[] = [];
+  private redoStack: UndoEntry[] = [];
   private nextId = 1;
   private maxEntries = 50;
   private currentNotice: Notice | null = null;
@@ -56,12 +60,16 @@ export class KanbanUndoManager {
     return this.stack.length > 0;
   }
 
+  canRedo() {
+    return this.redoStack.length > 0;
+  }
+
   capture(manager: StateManager): PendingFileState {
     return {
       manager,
       before: manager.state,
       beforeMd: manager.parser.boardToMd(manager.state),
-      viewStates: Array.from(manager.viewSet).map((view) => ({
+      beforeViewStates: Array.from(manager.viewSet).map((view) => ({
         state: cloneViewState(view.viewSettings),
       })),
     };
@@ -94,8 +102,12 @@ export class KanbanUndoManager {
         file: manager.file,
         before: beforeState.before,
         beforeMd: beforeState.beforeMd,
+        beforeViewStates: beforeState.beforeViewStates,
+        after: manager.state,
         afterMd,
-        viewStates: beforeState.viewStates,
+        afterViewStates: Array.from(manager.viewSet).map((view) => ({
+          state: cloneViewState(view.viewSettings),
+        })),
       });
     }
 
@@ -108,6 +120,7 @@ export class KanbanUndoManager {
     };
 
     this.stack.push(entry);
+    this.redoStack = [];
 
     if (this.stack.length > this.maxEntries) {
       this.stack.shift();
@@ -126,28 +139,51 @@ export class KanbanUndoManager {
       return;
     }
 
-    if (!(await this.canApply(entry))) {
+    if (!(await this.canApply(entry, 'before'))) {
       new Notice(t('Unable to undo because the board has changed'));
       return;
     }
 
     for (const fileState of entry.files) {
-      await this.restore(fileState);
+      await this.restore(fileState, 'before');
     }
 
     this.stack.pop();
+    this.redoStack.push(entry);
     this.dismissCurrentNotice();
   }
 
-  private async canApply(entry: UndoEntry) {
+  async redoLast() {
+    const entry = this.redoStack[this.redoStack.length - 1];
+
+    if (!entry) {
+      new Notice(t('Nothing to redo'));
+      return;
+    }
+
+    if (!(await this.canApply(entry, 'after'))) {
+      new Notice(t('Unable to redo because the board has changed'));
+      return;
+    }
+
+    for (const fileState of entry.files) {
+      await this.restore(fileState, 'after');
+    }
+
+    this.redoStack.pop();
+    this.stack.push(entry);
+    this.dismissCurrentNotice();
+  }
+
+  private async canApply(entry: UndoEntry, target: RestoreTarget) {
     for (const fileState of entry.files) {
       const manager = this.plugin.getStateManager(fileState.file);
+      const expectedMd = target === 'before' ? fileState.afterMd : fileState.beforeMd;
+      const currentMd = manager
+        ? manager.parser.boardToMd(manager.state)
+        : await this.plugin.app.vault.cachedRead(fileState.file);
 
-      if (manager) continue;
-
-      const currentMd = await this.plugin.app.vault.cachedRead(fileState.file);
-
-      if (currentMd !== fileState.afterMd) {
+      if (currentMd !== expectedMd) {
         return false;
       }
     }
@@ -155,18 +191,22 @@ export class KanbanUndoManager {
     return true;
   }
 
-  private async restore(fileState: UndoFileState) {
+  private async restore(fileState: UndoFileState, target: RestoreTarget) {
     const manager = this.plugin.getStateManager(fileState.file);
+    const board = target === 'before' ? fileState.before : fileState.after;
+    const md = target === 'before' ? fileState.beforeMd : fileState.afterMd;
+    const viewStates =
+      target === 'before' ? fileState.beforeViewStates : fileState.afterViewStates;
 
     if (!manager) {
-      await this.plugin.app.vault.modify(fileState.file, fileState.beforeMd);
+      await this.plugin.app.vault.modify(fileState.file, md);
       return;
     }
 
-    manager.setState(fileState.before);
+    manager.setState(board);
 
     Array.from(manager.viewSet).forEach((view, index) => {
-      const snapshot = fileState.viewStates[index];
+      const snapshot = viewStates[index];
       if (snapshot) {
         view.viewSettings = cloneViewState(snapshot.state);
       }

--- a/src/UndoManager.ts
+++ b/src/UndoManager.ts
@@ -1,0 +1,237 @@
+import { Notice, TFile, setIcon } from 'obsidian';
+
+import type KanbanPlugin from './main';
+import type { KanbanViewSettings } from './Settings';
+import type { StateManager } from './StateManager';
+import { Board } from './components/types';
+import { t } from './lang/helpers';
+
+interface ViewStateSnapshot {
+  state: KanbanViewSettings;
+}
+
+interface UndoFileState {
+  file: TFile;
+  before: Board;
+  beforeMd: string;
+  afterMd: string;
+  viewStates: ViewStateSnapshot[];
+}
+
+interface PendingFileState {
+  manager: StateManager;
+  before: Board;
+  beforeMd: string;
+  viewStates: ViewStateSnapshot[];
+}
+
+interface UndoEntry {
+  id: number;
+  label: string;
+  files: UndoFileState[];
+}
+
+type BoardUpdater = Board | ((board: Board) => Board);
+
+function cloneViewState(state: KanbanViewSettings): KanbanViewSettings {
+  const next = { ...state };
+
+  if (Array.isArray(next['list-collapse'])) {
+    next['list-collapse'] = [...next['list-collapse']];
+  }
+
+  return next;
+}
+
+export class KanbanUndoManager {
+  private stack: UndoEntry[] = [];
+  private nextId = 1;
+  private maxEntries = 50;
+  private currentNotice: Notice | null = null;
+  private currentNoticeTimer: number | null = null;
+
+  constructor(private plugin: KanbanPlugin) {}
+
+  canUndo() {
+    return this.stack.length > 0;
+  }
+
+  capture(manager: StateManager): PendingFileState {
+    return {
+      manager,
+      before: manager.state,
+      beforeMd: manager.parser.boardToMd(manager.state),
+      viewStates: Array.from(manager.viewSet).map((view) => ({
+        state: cloneViewState(view.viewSettings),
+      })),
+    };
+  }
+
+  run(label: string, manager: StateManager, updater: BoardUpdater) {
+    if (manager.getSetting('enable-undo') === false) {
+      manager.setState(updater);
+      return;
+    }
+
+    const before = this.capture(manager);
+
+    manager.setState(updater);
+
+    this.record(label, [before]);
+  }
+
+  record(label: string, beforeStates: PendingFileState[]) {
+    const files: UndoFileState[] = [];
+
+    for (const beforeState of beforeStates) {
+      const { manager } = beforeState;
+      const afterMd = manager.parser.boardToMd(manager.state);
+
+      if (manager.getSetting('enable-undo') === false) continue;
+      if (beforeState.beforeMd === afterMd) continue;
+
+      files.push({
+        file: manager.file,
+        before: beforeState.before,
+        beforeMd: beforeState.beforeMd,
+        afterMd,
+        viewStates: beforeState.viewStates,
+      });
+    }
+
+    if (!files.length) return;
+
+    const entry: UndoEntry = {
+      id: this.nextId++,
+      label,
+      files,
+    };
+
+    this.stack.push(entry);
+
+    if (this.stack.length > this.maxEntries) {
+      this.stack.shift();
+    }
+
+    if (files.some((file) => this.plugin.getStateManager(file.file)?.getSetting('show-undo-notice') !== false)) {
+      this.showUndoNotice(entry);
+    }
+  }
+
+  async undoLast() {
+    const entry = this.stack[this.stack.length - 1];
+
+    if (!entry) {
+      new Notice(t('Nothing to undo'));
+      return;
+    }
+
+    if (!(await this.canApply(entry))) {
+      new Notice(t('Unable to undo because the board has changed'));
+      return;
+    }
+
+    for (const fileState of entry.files) {
+      await this.restore(fileState);
+    }
+
+    this.stack.pop();
+    this.dismissCurrentNotice();
+  }
+
+  private async canApply(entry: UndoEntry) {
+    for (const fileState of entry.files) {
+      const manager = this.plugin.getStateManager(fileState.file);
+
+      if (manager) continue;
+
+      const currentMd = await this.plugin.app.vault.cachedRead(fileState.file);
+
+      if (currentMd !== fileState.afterMd) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private async restore(fileState: UndoFileState) {
+    const manager = this.plugin.getStateManager(fileState.file);
+
+    if (!manager) {
+      await this.plugin.app.vault.modify(fileState.file, fileState.beforeMd);
+      return;
+    }
+
+    manager.setState(fileState.before);
+
+    Array.from(manager.viewSet).forEach((view, index) => {
+      const snapshot = fileState.viewStates[index];
+      if (snapshot) {
+        view.viewSettings = cloneViewState(snapshot.state);
+      }
+    });
+  }
+
+  private showUndoNotice(entry: UndoEntry) {
+    this.dismissCurrentNotice(false);
+
+    const fragment = activeDocument.createDocumentFragment();
+    const chip = activeDocument.createElement('div');
+    const message = activeDocument.createElement('span');
+    const button = activeDocument.createElement('button');
+    let notice: Notice;
+
+    chip.addClass('kanban-plugin__undo-notice-chip');
+    message.textContent = entry.label;
+    message.addClass('kanban-plugin__undo-notice-label');
+    button.setAttr('aria-label', `${t('Undo')} ${entry.label}`);
+    button.setAttr('title', `${t('Undo')} ${entry.label}`);
+    button.addClass('kanban-plugin__undo-notice-button');
+    setIcon(button, 'lucide-undo-2');
+    button.onclick = async () => {
+      await this.undoEntry(entry);
+    };
+
+    chip.append(message, button);
+    fragment.append(chip);
+    notice = new Notice(fragment, 0);
+    notice.noticeEl.addClass('kanban-plugin__undo-notice');
+    this.currentNotice = notice;
+
+    this.currentNoticeTimer = activeWindow.setTimeout(() => {
+      if (this.currentNotice === notice) {
+        this.dismissCurrentNotice();
+      }
+    }, 3000);
+  }
+
+  private async undoEntry(entry: UndoEntry) {
+    if (this.stack[this.stack.length - 1]?.id !== entry.id) return;
+
+    await this.undoLast();
+  }
+
+  private dismissCurrentNotice(animate: boolean = true) {
+    const notice = this.currentNotice;
+
+    if (!notice) return;
+
+    if (this.currentNoticeTimer !== null) {
+      activeWindow.clearTimeout(this.currentNoticeTimer);
+      this.currentNoticeTimer = null;
+    }
+
+    this.currentNotice = null;
+
+    if (!animate) {
+      notice.hide();
+      return;
+    }
+
+    notice.noticeEl.addClass('kanban-plugin__undo-notice-dismissing');
+    activeWindow.setTimeout(() => {
+      notice.hide();
+    }, 360);
+  }
+}

--- a/src/components/Editor/MarkdownEditor.tsx
+++ b/src/components/Editor/MarkdownEditor.tsx
@@ -141,6 +141,8 @@ export function MarkdownEditor({
             EditorView.domEventHandlers({
               focus: (evt) => {
                 view.activeEditor = this.owner;
+                this.app.workspace.activeEditor = this.owner;
+
                 if (Platform.isMobile) {
                   view.contentEl.addClass('is-mobile-editing');
                 }
@@ -154,6 +156,14 @@ export function MarkdownEditor({
                 return true;
               },
               blur: () => {
+                if (view.activeEditor === this.owner) {
+                  view.activeEditor = null;
+                }
+
+                if (this.app.workspace.activeEditor === this.owner) {
+                  this.app.workspace.activeEditor = null;
+                }
+
                 if (Platform.isMobile) {
                   view.contentEl.removeClass('is-mobile-editing');
                   this.app.mobileToolbar.update();
@@ -247,18 +257,18 @@ export function MarkdownEditor({
     }
 
     return () => {
+      if (view.activeEditor === controller) {
+        view.activeEditor = null;
+      }
+
+      if (app.workspace.activeEditor === controller) {
+        app.workspace.activeEditor = null;
+      }
+
       if (Platform.isMobile) {
         cm.dom.win.removeEventListener('keyboardDidShow', onShow);
-
-        if (view.activeEditor === controller) {
-          view.activeEditor = null;
-        }
-
-        if (app.workspace.activeEditor === controller) {
-          app.workspace.activeEditor = null;
-          (app as any).mobileToolbar.update();
-          view.contentEl.removeClass('is-mobile-editing');
-        }
+        (app as any).mobileToolbar.update();
+        view.contentEl.removeClass('is-mobile-editing');
       }
       view.plugin.removeChild(editor);
       internalRef.current = null;

--- a/src/components/Item/ItemCheckbox.tsx
+++ b/src/components/Item/ItemCheckbox.tsx
@@ -2,6 +2,7 @@ import update from 'immutability-helper';
 import { memo, useCallback, useEffect, useState } from 'preact/compat';
 import { StateManager } from 'src/StateManager';
 import { Path } from 'src/dnd/types';
+import { t } from 'src/lang/helpers';
 import { getTaskStatusDone, toggleTask } from 'src/parsers/helpers/inlineMetadata';
 
 import { BoardModifiers } from '../../helpers/boardModifiers';
@@ -30,6 +31,8 @@ export const ItemCheckbox = memo(function ItemCheckbox({
   const [isHoveringCheckbox, setIsHoveringCheckbox] = useState(false);
 
   const onCheckboxChange = useCallback(() => {
+    const before = stateManager.undoManager?.capture(stateManager);
+    const label = item.data.checked ? t('Uncheck card') : t('Complete card');
     const updates = toggleTask(item, stateManager.file);
     if (updates) {
       const [itemStrings, checkChars, thisIndex] = updates;
@@ -54,6 +57,10 @@ export const ItemCheckbox = memo(function ItemCheckbox({
           },
         })
       );
+    }
+
+    if (before) {
+      stateManager.undoManager?.record(label, [before]);
     }
   }, [item, stateManager, boardModifiers, ...path]);
 

--- a/src/components/Item/ItemContent.tsx
+++ b/src/components/Item/ItemContent.tsx
@@ -12,6 +12,7 @@ import {
 import { StateManager } from 'src/StateManager';
 import { useNestedEntityPath } from 'src/dnd/components/Droppable';
 import { Path } from 'src/dnd/types';
+import { t } from 'src/lang/helpers';
 import { getTaskStatusDone, toggleTaskString } from 'src/parsers/helpers/inlineMetadata';
 
 import { MarkdownEditor, allowNewLine } from '../Editor/MarkdownEditor';
@@ -247,8 +248,13 @@ export const ItemContent = memo(function ItemContent({
         const checkboxIndex = parseInt(target.dataset.checkboxIndex, 10);
         const checked = checkCheckbox(stateManager, item.data.titleRaw, checkboxIndex);
         const updated = stateManager.updateItemContent(item, checked);
+        const before = stateManager.undoManager?.capture(stateManager);
 
         boardModifiers.updateItem(path, updated);
+
+        if (before) {
+          stateManager.undoManager?.record(t('Toggle checkbox'), [before]);
+        }
       }
     },
     [path, boardModifiers, stateManager, item]

--- a/src/components/Item/ItemForm.tsx
+++ b/src/components/Item/ItemForm.tsx
@@ -1,6 +1,6 @@
 import { EditorView } from '@codemirror/view';
-import { Dispatch, StateUpdater, useContext, useRef } from 'preact/hooks';
-import useOnclickOutside from 'react-cool-onclickoutside';
+import { App, Modal, Setting } from 'obsidian';
+import { Dispatch, StateUpdater, useCallback, useContext, useEffect, useRef } from 'preact/hooks';
 import { t } from 'src/lang/helpers';
 
 import { MarkdownEditor, allowNewLine } from '../Editor/MarkdownEditor';
@@ -16,14 +16,117 @@ interface ItemFormProps {
   hideButton?: boolean;
 }
 
+class DiscardCardDraftModal extends Modal {
+  private shouldRestoreEditor = true;
+
+  constructor(app: App, private onDiscard: () => void, private onKeepEditing: () => void) {
+    super(app);
+  }
+
+  onOpen() {
+    this.setTitle(t('Discard card draft?'));
+
+    this.contentEl.createEl('p', {
+      text: t('This card has text that has not been saved.'),
+    });
+
+    new Setting(this.contentEl)
+      .addButton((button) => {
+        button
+          .setButtonText(t('Keep editing'))
+          .setCta()
+          .onClick(() => {
+            this.close();
+          });
+      })
+      .addButton((button) => {
+        button
+          .setButtonText(t('Discard draft'))
+          .setWarning()
+          .onClick(() => {
+            this.shouldRestoreEditor = false;
+            this.close();
+            this.onDiscard();
+          });
+      });
+  }
+
+  onClose() {
+    this.contentEl.empty();
+    if (this.shouldRestoreEditor) {
+      this.onKeepEditing();
+    }
+  }
+}
+
 export function ItemForm({ addItems, editState, setEditState, hideButton }: ItemFormProps) {
   const { stateManager } = useContext(KanbanContext);
   const editorRef = useRef<EditorView>();
+  const formRef = useRef<HTMLDivElement>();
+  const isPromptOpenRef = useRef(false);
 
   const clear = () => setEditState(EditingState.cancel);
-  const clickOutsideRef = useOnclickOutside(clear, {
-    ignoreClass: [c('ignore-click-outside'), 'mobile-toolbar', 'suggestion-container'],
-  });
+
+  const confirmDiscardDraft = useCallback(
+    (cm: EditorView) => {
+      if (!cm.state.doc.toString().trim()) {
+        clear();
+        return;
+      }
+
+      if (isPromptOpenRef.current) return;
+      isPromptOpenRef.current = true;
+
+      new DiscardCardDraftModal(
+        stateManager.app,
+        () => {
+          isPromptOpenRef.current = false;
+          clear();
+        },
+        () => {
+          isPromptOpenRef.current = false;
+          cm.focus();
+        }
+      ).open();
+    },
+    [stateManager]
+  );
+
+  useEffect(() => {
+    if (!isEditing(editState)) return;
+
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target as HTMLElement;
+      const cm = editorRef.current;
+      const formEl = formRef.current;
+
+      if (!cm || !formEl || formEl.contains(target)) return;
+      if (
+        target.closest(`.${c('ignore-click-outside')}`) ||
+        target.closest('.mobile-toolbar') ||
+        target.closest('.suggestion-container') ||
+        target.closest('.modal-container')
+      ) {
+        return;
+      }
+
+      if (!cm.state.doc.toString().trim()) {
+        clear();
+        return;
+      }
+
+      e.preventDefault();
+      e.stopPropagation();
+      e.stopImmediatePropagation();
+      confirmDiscardDraft(cm);
+    };
+
+    activeDocument.addEventListener('pointerdown', onPointerDown, true);
+
+    return () => {
+      activeDocument.removeEventListener('pointerdown', onPointerDown, true);
+    };
+  }, [editState, confirmDiscardDraft]);
 
   const createItem = (title: string) => {
     addItems([stateManager.getNewItem(title, ' ')]);
@@ -41,7 +144,7 @@ export function ItemForm({ addItems, editState, setEditState, hideButton }: Item
 
   if (isEditing(editState)) {
     return (
-      <div className={c('item-form')} ref={clickOutsideRef}>
+      <div className={c('item-form')} ref={formRef}>
         <div className={c('item-input-wrapper')}>
           <MarkdownEditor
             editorRef={editorRef}
@@ -57,7 +160,9 @@ export function ItemForm({ addItems, editState, setEditState, hideButton }: Item
             onSubmit={(cm) => {
               createItem(cm.state.doc.toString());
             }}
-            onEscape={clear}
+            onEscape={(cm) => {
+              confirmDiscardDraft(cm);
+            }}
           />
         </div>
       </div>

--- a/src/components/Item/ItemMenu.ts
+++ b/src/components/Item/ItemMenu.ts
@@ -3,7 +3,6 @@ import { Menu, Platform, TFile, TFolder } from 'obsidian';
 import { Dispatch, StateUpdater, useCallback } from 'preact/hooks';
 import { StateManager } from 'src/StateManager';
 import { Path } from 'src/dnd/types';
-import { moveEntity } from 'src/dnd/util/data';
 import { t } from 'src/lang/helpers';
 
 import { BoardModifiers } from '../../helpers/boardModifiers';
@@ -276,9 +275,7 @@ export function useItemMenu({
               .setTitle(lanes[i].data.title)
               .onClick(() => {
                 if (path[0] === i) return;
-                stateManager.setState((boardData) => {
-                  return moveEntity(boardData, path, [i, 0]);
-                });
+                boardModifiers.moveItemToLane(path, i);
               })
           );
         }

--- a/src/components/Table/Cells.tsx
+++ b/src/components/Table/Cells.tsx
@@ -3,7 +3,6 @@ import { Menu } from 'obsidian';
 import { JSX, memo, useCallback, useContext, useState } from 'preact/compat';
 import isEqual from 'react-fast-compare';
 import { ExplicitPathContext } from 'src/dnd/components/context';
-import { moveEntity } from 'src/dnd/util/data';
 
 import { Icon } from '../Icon/Icon';
 import { DateAndTime, RelativeDate } from '../Item/DateAndTime';
@@ -121,7 +120,7 @@ export const ItemCell = memo(
 );
 
 export const LaneCell = memo(function LaneCell({ lane, path }: { lane: Lane; path: number[] }) {
-  const { stateManager } = useContext(KanbanContext);
+  const { boardModifiers, stateManager } = useContext(KanbanContext);
   const search = useContext(SearchContext);
   return (
     <div className={c('cell-flex-wrapper')}>
@@ -139,10 +138,7 @@ export const LaneCell = memo(function LaneCell({ lane, path }: { lane: Lane; pat
                 .setTitle(l.data.title)
                 .onClick(() => {
                   if (lane === l) return;
-                  stateManager.setState((boardData) => {
-                    const target = boardData.children[i];
-                    return moveEntity(boardData, path, [i, target.children.length]);
-                  });
+                  boardModifiers.moveItemToLane(path, i, true);
                 })
             );
           }

--- a/src/helpers/boardModifiers.ts
+++ b/src/helpers/boardModifiers.ts
@@ -16,6 +16,7 @@ import {
 
 import { generateInstanceId } from '../components/helpers';
 import { Board, DataTypes, Item, Lane } from '../components/types';
+import { t } from '../lang/helpers';
 
 export interface BoardModifiers {
   appendItems: (path: Path, items: Item[]) => void;
@@ -25,6 +26,7 @@ export interface BoardModifiers {
   splitItem: (path: Path, items: Item[]) => void;
   moveItemToTop: (path: Path) => void;
   moveItemToBottom: (path: Path) => void;
+  moveItemToLane: (path: Path, laneIndex: number, shouldAppend?: boolean) => void;
   addLane: (lane: Lane) => void;
   insertLane: (path: Path, lane: Lane) => void;
   updateLane: (path: Path, lane: Lane) => void;
@@ -80,14 +82,24 @@ export function getBoardModifiers(view: KanbanView, stateManager: StateManager):
     },
 
     moveItemToTop: (path: Path) => {
-      stateManager.setState((boardData) => moveEntity(boardData, path, [path[0], 0]));
+      view.plugin.undoManager.run(t('Move card'), stateManager, (boardData) =>
+        moveEntity(boardData, path, [path[0], 0])
+      );
     },
 
     moveItemToBottom: (path: Path) => {
-      stateManager.setState((boardData) => {
+      view.plugin.undoManager.run(t('Move card'), stateManager, (boardData) => {
         const laneIndex = path[0];
         const lane = boardData.children[laneIndex];
         return moveEntity(boardData, path, [laneIndex, lane.children.length]);
+      });
+    },
+
+    moveItemToLane: (path: Path, laneIndex: number, shouldAppend: boolean = false) => {
+      view.plugin.undoManager.run(t('Move card'), stateManager, (boardData) => {
+        const lane = boardData.children[laneIndex];
+        const itemIndex = shouldAppend ? lane.children.length : 0;
+        return moveEntity(boardData, path, [laneIndex, itemIndex]);
       });
     },
 
@@ -137,7 +149,7 @@ export function getBoardModifiers(view: KanbanView, stateManager: StateManager):
     },
 
     archiveLane: (path: Path) => {
-      stateManager.setState((boardData) => {
+      view.plugin.undoManager.run(t('Archive list'), stateManager, (boardData) => {
         const lane = getEntityFromPath(boardData, path);
         const items = lane.children;
 
@@ -168,7 +180,7 @@ export function getBoardModifiers(view: KanbanView, stateManager: StateManager):
     },
 
     archiveLaneItems: (path: Path) => {
-      stateManager.setState((boardData) => {
+      view.plugin.undoManager.run(t('Archive cards'), stateManager, (boardData) => {
         const lane = getEntityFromPath(boardData, path);
         const items = lane.children;
 
@@ -197,7 +209,10 @@ export function getBoardModifiers(view: KanbanView, stateManager: StateManager):
     },
 
     deleteEntity: (path: Path) => {
-      stateManager.setState((boardData) => {
+      const entity = getEntityFromPath(stateManager.state, path);
+      const label = entity.type === DataTypes.Lane ? t('Delete list') : t('Delete card');
+
+      view.plugin.undoManager.run(label, stateManager, (boardData) => {
         const entity = getEntityFromPath(boardData, path);
 
         if (entity.type === DataTypes.Lane) {
@@ -231,7 +246,7 @@ export function getBoardModifiers(view: KanbanView, stateManager: StateManager):
     },
 
     archiveItem: (path: Path) => {
-      stateManager.setState((boardData) => {
+      view.plugin.undoManager.run(t('Archive card'), stateManager, (boardData) => {
         const item = getEntityFromPath(boardData, path);
         try {
           return update(removeEntity(boardData, path), {

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -12,6 +12,11 @@ const en = {
   'New kanban board': 'New kanban board',
   'Untitled Kanban': 'Untitled Kanban',
   'Toggle between Kanban and markdown mode': 'Toggle between Kanban and markdown mode',
+  'Undo last Kanban action': 'Undo last Kanban action',
+  'Nothing to undo': 'Nothing to undo',
+  'Unable to undo because the board has changed': 'Unable to undo because the board has changed',
+  'Undid Kanban action': 'Undid Kanban action',
+  Undo: 'Undo',
 
   'View as board': 'View as board',
   'View as list': 'View as list',
@@ -46,6 +51,12 @@ const en = {
   'New line trigger': 'New line trigger',
   'Select whether Enter or Shift+Enter creates a new line. The opposite of what you choose will create and complete editing of cards and lists.':
     'Select whether Enter or Shift+Enter creates a new line. The opposite of what you choose will create and complete editing of cards and lists.',
+  'Enable undo': 'Enable undo',
+  'When toggled, archive, move, and delete actions can be undone from Kanban.':
+    'When toggled, archive, move, and delete actions can be undone from Kanban.',
+  'Show undo notice': 'Show undo notice',
+  'Shows a small undo chip after undoable actions. This can be convenient, but it may get in the way; undo is still available from the command palette and keyboard shortcut when this is off.':
+    'Shows a small undo chip after undoable actions. This can be convenient, but it may get in the way; undo is still available from the command palette and keyboard shortcut when this is off.',
   'Shift + Enter': 'Shift + Enter',
   Enter: 'Enter',
   'Prepend / append new cards': 'Prepend / append new cards',
@@ -215,6 +226,10 @@ const en = {
   'Card title...': 'Card title...',
   'Add card': 'Add card',
   'Add a card': 'Add a card',
+  'Discard card draft?': 'Discard card draft?',
+  'This card has text that has not been saved.': 'This card has text that has not been saved.',
+  'Keep editing': 'Keep editing',
+  'Discard draft': 'Discard draft',
 
   // components/Item/ItemMenu.ts
   'Edit card': 'Edit card',
@@ -236,6 +251,10 @@ const en = {
   'Move to top': 'Move to top',
   'Move to bottom': 'Move to bottom',
   'Move to list': 'Move to list',
+  'Move card': 'Move card',
+  'Complete card': 'Complete card',
+  'Uncheck card': 'Uncheck card',
+  'Toggle checkbox': 'Toggle checkbox',
 
   // components/Lane/LaneForm.tsx
   'Enter list title...': 'Enter list title...',

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -13,8 +13,11 @@ const en = {
   'Untitled Kanban': 'Untitled Kanban',
   'Toggle between Kanban and markdown mode': 'Toggle between Kanban and markdown mode',
   'Undo last Kanban action': 'Undo last Kanban action',
+  'Redo last Kanban action': 'Redo last Kanban action',
   'Nothing to undo': 'Nothing to undo',
+  'Nothing to redo': 'Nothing to redo',
   'Unable to undo because the board has changed': 'Unable to undo because the board has changed',
+  'Unable to redo because the board has changed': 'Unable to redo because the board has changed',
   'Undid Kanban action': 'Undid Kanban action',
   Undo: 'Undo',
 
@@ -53,7 +56,7 @@ const en = {
     'Select whether Enter or Shift+Enter creates a new line. The opposite of what you choose will create and complete editing of cards and lists.',
   'Enable undo': 'Enable undo',
   'When toggled, archive, move, and delete actions can be undone from Kanban.':
-    'When toggled, archive, move, and delete actions can be undone from Kanban.',
+    'When toggled, archive, move, and delete actions can be undone and redone from Kanban.',
   'Show undo notice': 'Show undo notice',
   'Shows a small undo chip after undoable actions. This can be convenient, but it may get in the way; undo is still available from the command palette and keyboard shortcut when this is off.':
     'Shows a small undo chip after undoable actions. This can be convenient, but it may get in the way; undo is still available from the command palette and keyboard shortcut when this is off.',

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import { createApp } from './DragDropApp';
 import { KanbanView, kanbanIcon, kanbanViewType } from './KanbanView';
 import { KanbanSettings, KanbanSettingsTab } from './Settings';
 import { StateManager } from './StateManager';
+import { KanbanUndoManager } from './UndoManager';
 import { DateSuggest, TimeSuggest } from './components/Editor/suggest';
 import { getParentWindow } from './dnd/util/getWindow';
 import { hasFrontmatterKey } from './helpers';
@@ -52,6 +53,7 @@ export default class KanbanPlugin extends Plugin {
   // leafid => view mode
   kanbanFileModes: Record<string, string> = {};
   stateManagers: Map<TFile, StateManager> = new Map();
+  undoManager = new KanbanUndoManager(this);
 
   windowRegistry: Map<Window, WindowRegistry> = new Map();
 
@@ -143,6 +145,7 @@ export default class KanbanPlugin extends Plugin {
 
     this.registerDomEvent(window, 'keydown', this.handleShift);
     this.registerDomEvent(window, 'keyup', this.handleShift);
+    this.registerDomEvent(window, 'keydown', this.handleUndoHotkey, true);
 
     this.addRibbonIcon(kanbanIcon, t('Create new board'), () => {
       this.newKanban();
@@ -151,6 +154,20 @@ export default class KanbanPlugin extends Plugin {
 
   handleShift = (e: KeyboardEvent) => {
     this.isShiftPressed = e.shiftKey;
+  };
+
+  handleUndoHotkey = (e: KeyboardEvent) => {
+    const isUndo =
+      (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === 'z';
+
+    if (!isUndo || e.defaultPrevented) return;
+
+    const view = this.app.workspace.getActiveViewOfType(KanbanView);
+    if (!view || view.activeEditor || !this.undoManager.canUndo()) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+    this.undoManager.undoLast();
   };
 
   getKanbanViews(win: Window) {
@@ -230,7 +247,8 @@ export default class KanbanPlugin extends Plugin {
           view,
           data,
           () => this.stateManagers.delete(file),
-          () => this.settings
+          () => this.settings,
+          this.undoManager
         )
       );
     }
@@ -719,6 +737,17 @@ export default class KanbanPlugin extends Plugin {
         if (checking) return true;
 
         view.getBoardSettings();
+      },
+    });
+
+    this.addCommand({
+      id: 'undo-last-kanban-action',
+      name: t('Undo last Kanban action'),
+      checkCallback: (checking) => {
+        if (!this.undoManager.canUndo()) return false;
+        if (checking) return true;
+
+        this.undoManager.undoLast();
       },
     });
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -159,15 +159,25 @@ export default class KanbanPlugin extends Plugin {
   handleUndoHotkey = (e: KeyboardEvent) => {
     const isUndo =
       (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === 'z';
+    const isRedo =
+      ((e.metaKey || e.ctrlKey) && e.shiftKey && !e.altKey && e.key.toLowerCase() === 'z') ||
+      (e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey && e.key.toLowerCase() === 'y');
 
-    if (!isUndo || e.defaultPrevented) return;
+    if ((!isUndo && !isRedo) || e.defaultPrevented) return;
 
     const view = this.app.workspace.getActiveViewOfType(KanbanView);
-    if (!view || view.activeEditor || !this.undoManager.canUndo()) return;
+    if (!view || view.activeEditor) return;
+    if (isUndo && !this.undoManager.canUndo()) return;
+    if (isRedo && !this.undoManager.canRedo()) return;
 
     e.preventDefault();
     e.stopPropagation();
-    this.undoManager.undoLast();
+
+    if (isUndo) {
+      this.undoManager.undoLast();
+    } else {
+      this.undoManager.redoLast();
+    }
   };
 
   getKanbanViews(win: Window) {
@@ -748,6 +758,17 @@ export default class KanbanPlugin extends Plugin {
         if (checking) return true;
 
         this.undoManager.undoLast();
+      },
+    });
+
+    this.addCommand({
+      id: 'redo-last-kanban-action',
+      name: t('Redo last Kanban action'),
+      checkCallback: (checking) => {
+        if (!this.undoManager.canRedo()) return false;
+        if (checking) return true;
+
+        this.undoManager.redoLast();
       },
     });
   }

--- a/src/styles.less
+++ b/src/styles.less
@@ -385,7 +385,7 @@ button.kanban-plugin__search-cancel-button .kanban-plugin__icon {
 button.kanban-plugin__item-action-add,
 button.kanban-plugin__lane-action-add {
   background-color: var(--interactive-accent);
-  color: var(--text-on-accent);
+  color: #fff;
   &:hover {
     background-color: var(--interactive-accent-hover);
   }
@@ -495,7 +495,7 @@ div.kanban-plugin__lane-title-count {
 
 div.kanban-plugin__lane-title-count.wip-exceeded {
   font-weight: bold;
-  color: var(--text-normal);
+  color: var(--text-on-accent);
   background-color: rgba(var(--background-modifier-error-rgb), 0.25);
 }
 
@@ -1784,5 +1784,100 @@ body:not(.native-scrollbars) .kanban-plugin__scroll-container::-webkit-scrollbar
 .kanban-plugin__meta-value {
   .kanban-plugin__date:hover {
     background-color: var(--date-background-color, rgba(var(--mono-rgb-100), 0.05));
+  }
+}
+
+.notice-container:has(.kanban-plugin__undo-notice) {
+  top: unset;
+  right: var(--size-4-4);
+  bottom: var(--size-4-4);
+  left: unset;
+  align-items: flex-end;
+}
+
+.kanban-plugin__undo-notice {
+  display: flex;
+  justify-content: flex-end;
+  align-self: flex-end;
+  min-width: 0;
+  max-width: max-content;
+  width: auto;
+  min-height: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  animation: kanban-plugin-undo-notice-in 280ms cubic-bezier(0.16, 1, 0.3, 1);
+  transition: opacity 360ms ease, transform 360ms ease;
+
+  > div {
+    padding: 0;
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+  }
+}
+
+.kanban-plugin__undo-notice.kanban-plugin__undo-notice-dismissing {
+  opacity: 0;
+  transform: translateY(-12px);
+}
+
+@keyframes kanban-plugin-undo-notice-in {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.kanban-plugin__undo-notice-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  width: max-content;
+  min-height: 0;
+  padding: 5px 6px 5px 10px;
+  border-radius: 18px;
+  color: var(--text-normal);
+  background: var(--background-primary);
+  box-shadow: 0 1px 8px rgba(var(--mono-rgb-100), 0.18);
+
+  .kanban-plugin__undo-notice-label {
+    max-width: 160px;
+    overflow: hidden;
+    font-size: var(--font-ui-smaller);
+    line-height: 1;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    color: #fff;
+  }
+
+  .kanban-plugin__undo-notice-button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    margin: 0;
+    padding: 0;
+    border: none;
+    border-radius: 50%;
+    color: #fff;
+    background: var(--interactive-accent);
+    box-shadow: none;
+
+    &:hover {
+      background: var(--interactive-accent-hover);
+    }
+
+    svg {
+      width: 13px;
+      height: 13px;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add an undo manager for Kanban board actions
- support undo/redo for moving, archiving, deleting, checkbox completion, and archive-completed actions
- add command palette commands and keyboard handling for Kanban undo/redo
- add settings for enabling undo and optional undo notices
- add draft-discard confirmation for new cards with unsaved text

## Validation
- corepack yarn typecheck
- corepack yarn lint
- corepack yarn build

## Notes
- Undo notices are off by default so command palette / keyboard undo remains available without toast UI.
- Redo is cleared when a new Kanban action is recorded, matching normal editor behavior.