### PR TITLE
fix: validate configured new-note folders

### DIFF
--- a/src/components/Item/ItemMenu.ts
+++ b/src/components/Item/ItemMenu.ts
@@ -68,9 +68,15 @@ export function useItemMenu({
               const newNoteFolder = stateManager.getSetting('new-note-folder');
               const newNoteTemplatePath = stateManager.getSetting('new-note-template');
 
-              const targetFolder = newNoteFolder
-                ? (stateManager.app.vault.getAbstractFileByPath(newNoteFolder as string) as TFolder)
-                : stateManager.app.fileManager.getNewFileParent(stateManager.file.path);
+              const getNoteFolder = (path?: string | null) => {
+                const file = path ? stateManager.app.vault.getAbstractFileByPath(path) : null;
+
+                return file instanceof TFolder ? file : null;
+              };
+              const targetFolder =
+                getNoteFolder(newNoteFolder) ??
+                getNoteFolder(stateManager.getGlobalSetting('new-note-folder')) ??
+                stateManager.app.fileManager.getNewFileParent(stateManager.file.path);
 
               const newFile = (await (stateManager.app.fileManager as any).createNewMarkdownFile(
                 targetFolder,


### PR DESCRIPTION
## Summary

- validate the configured note destination at runtime before creating a note
- fall back from a missing or invalid board-level value to a valid global Note folder
- use Obsidian's existing default new-note parent when no configured path resolves to a folder

## Reproduction

The current code casts the result of `getAbstractFileByPath()` to `TFolder` without validating the runtime object.

This causes several related failure modes:

- a persisted board-level `new-note-folder: null` masks a valid global Note folder and creates the note in the default location
- a stale/deleted path passes `null` to `createNewMarkdownFile`
- a path resolving to a file throws `getParentPrefix is not a function`

Existing valid global, nested, Unicode, and board-local folder paths continue to work.

## Testing

- `yarn typecheck`
- `yarn lint`
- `yarn build`
- `git diff --check`
- automated Obsidian matrix covering valid global/nested/local folders, local `null`, stale paths, file-valued paths, no configuration, settings debounce, and plugin reload

Fixes #996
