### PR TITLE
Fix Note folder dropdown in popout windows, validate note folder path…

### DIFF
--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -218,6 +218,13 @@ const context = await esbuild.context({
         cancelAnimationFrame: 'activeWindow.cancelAnimationFrame',
       },
     }),
+    replace({
+      include: /choices\.js/,
+      values: {
+        document: 'activeDocument',
+        window: 'activeWindow',
+      },
+    }),
   ],
   external: [
     'obsidian',

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "obsidian-kanban",
 	"name": "Kanban",
-	"version": "2.0.51",
+	"version": "2.0.52",
 	"minAppVersion": "1.0.0",
 	"description": "Create markdown-backed Kanban boards in Obsidian.",
 	"author": "mgmeyers",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-kanban",
-  "version": "2.0.51",
+  "version": "2.0.52",
   "description": "This is a sample plugin for Obsidian (https://obsidian.md)",
   "main": "main.js",
   "scripts": {

--- a/src/Settings.ts
+++ b/src/Settings.ts
@@ -90,6 +90,7 @@ export interface KanbanSettings {
   'tag-sort'?: TagSort[];
   'time-format'?: string;
   'time-trigger'?: string;
+  'debug-logging'?: boolean;
 }
 
 export interface KanbanViewSettings {
@@ -138,6 +139,7 @@ export const settingKeyLookup: Set<keyof KanbanSettings> = new Set([
   'tag-sort',
   'time-format',
   'time-trigger',
+  'debug-logging',
 ]);
 
 export type SettingRetriever = <K extends keyof KanbanSettings>(
@@ -1530,6 +1532,56 @@ export class SettingsManager {
             });
         });
     });
+
+    contentEl.createEl('br');
+    contentEl.createEl('h4', { text: t('Debug') });
+
+    new Setting(contentEl)
+      .setName(t('Debug logging'))
+      .setDesc(
+        t(
+          'When toggled, the plugin will print detailed diagnostic logs to the developer console (Ctrl+Shift+I). Useful for troubleshooting the Note folder dropdown and other Choices.js-related issues. Off by default.'
+        )
+      )
+      .then((setting) => {
+        let toggleComponent: ToggleComponent;
+
+        setting
+          .addToggle((toggle) => {
+            toggleComponent = toggle;
+
+            const [value, globalValue] = this.getSetting('debug-logging', local);
+
+            if (value !== undefined && value !== null) {
+              toggle.setValue(value as boolean);
+            } else if (globalValue !== undefined && globalValue !== null) {
+              toggle.setValue(globalValue as boolean);
+            } else {
+              // default off
+              toggle.setValue(false);
+            }
+
+            toggle.onChange((newValue) => {
+              this.applySettingsUpdate({
+                'debug-logging': {
+                  $set: newValue,
+                },
+              });
+            });
+          })
+          .addExtraButton((b) => {
+            b.setIcon('lucide-rotate-ccw')
+              .setTooltip(t('Reset to default'))
+              .onClick(() => {
+                const [, globalValue] = this.getSetting('debug-logging', local);
+                toggleComponent.setValue(!!globalValue);
+
+                this.applySettingsUpdate({
+                  $unset: ['debug-logging'],
+                });
+              });
+          });
+      });
   }
 
   cleanUp() {

--- a/src/components/Item/ItemMenu.ts
+++ b/src/components/Item/ItemMenu.ts
@@ -68,9 +68,21 @@ export function useItemMenu({
               const newNoteFolder = stateManager.getSetting('new-note-folder');
               const newNoteTemplatePath = stateManager.getSetting('new-note-template');
 
-              const targetFolder = newNoteFolder
-                ? (stateManager.app.vault.getAbstractFileByPath(newNoteFolder as string) as TFolder)
-                : stateManager.app.fileManager.getNewFileParent(stateManager.file.path);
+              // Resolve the target folder, validating that a configured path
+              // actually points to an existing TFolder. Falls back to the board's
+              // default parent when the configured folder is missing, stale, or
+              // accidentally points to a file (see upstream issue #996 / PR #1228).
+              let targetFolder: TFolder;
+              if (newNoteFolder) {
+                const resolved = stateManager.app.vault.getAbstractFileByPath(newNoteFolder as string);
+                if (resolved instanceof TFolder) {
+                  targetFolder = resolved;
+                } else {
+                  targetFolder = stateManager.app.fileManager.getNewFileParent(stateManager.file.path);
+                }
+              } else {
+                targetFolder = stateManager.app.fileManager.getNewFileParent(stateManager.file.path);
+              }
 
               const newFile = (await (stateManager.app.fileManager as any).createNewMarkdownFile(
                 targetFolder,

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -18,6 +18,12 @@ const en = {
   'View as table': 'View as table',
   'Board view': 'Board view',
 
+  // Debug
+  'Debug': 'Debug',
+  'Debug logging': 'Debug logging',
+  'When toggled, the plugin will print detailed diagnostic logs to the developer console (Ctrl+Shift+I). Useful for troubleshooting the Note folder dropdown and other Choices.js-related issues. Off by default.':
+    'When toggled, the plugin will print detailed diagnostic logs to the developer console (Ctrl+Shift+I). Useful for troubleshooting the Note folder dropdown and other Choices.js-related issues. Off by default.',
+
   // KanbanView.tsx
   'Open as markdown': 'Open as markdown',
   'Open board settings': 'Open board settings',

--- a/src/lang/locale/ru.ts
+++ b/src/lang/locale/ru.ts
@@ -14,6 +14,17 @@ const lang: Partial<Lang> = {
   'Untitled Kanban': 'Безымянная Kanban-доска',
   'Toggle between Kanban and markdown mode': 'Переключиться между Kanban и markdown режимами',
 
+  'View as board': 'Показать как доску',
+  'View as list': 'Показать как список',
+  'View as table': 'Показать как таблицу',
+  'Board view': 'Вид доски',
+
+  // Debug
+  'Debug': 'Отладка',
+  'Debug logging': 'Диагностическое логирование',
+  'When toggled, the plugin will print detailed diagnostic logs to the developer console (Ctrl+Shift+I). Useful for troubleshooting the Note folder dropdown and other Choices.js-related issues. Off by default.':
+    'Если включено, плагин выводит подробные диагностические логи в консоль разработчика (Ctrl+Shift+I). Полезно для отладки выпадающего списка «Папка для заметок» и других проблем, связанных с Choices.js. По умолчанию выключено.',
+
   // KanbanView.tsx
   'Open as markdown': 'Открыть как markdown',
   'Open board settings': 'Открыть настройки доски',
@@ -22,7 +33,7 @@ const lang: Partial<Lang> = {
   'You may wish to open as markdown and inspect or edit the file.':
     'Вы можете открыть файл как markdown и проверить или отредактировать его.',
   'Are you sure you want to archive all completed cards on this board?':
-    'Вы уверены, что хотите архивировать все завершёённые карточки в этой доске?',
+    'Вы уверены, что хотите архивировать все завершённые карточки в этой доске?',
 
   // parser.ts
   Complete: 'Выполнено',
@@ -62,6 +73,7 @@ const lang: Partial<Lang> = {
   'Notes created from Kanban cards will be placed in this folder. If blank, they will be placed in the default location for this vault.':
     'В эту папку будут помещены заметки, созданные из карточек Kanban. Если поле пустое, они будут помещены в папку по умолчанию для этого хранилища.',
   'Default folder': 'Директория по умолчанию',
+  'Expand lists to full width in list view': 'Раскрывать списки на полную ширину в режиме списка',
   'List width': 'Ширина списка',
   'Enter a number to set the list width in pixels.':
     'Введите число, чтобы установить ширину списка в пикселях.',
@@ -88,6 +100,25 @@ const lang: Partial<Lang> = {
   'This format will be used when displaying dates in Kanban cards.':
     'Этот формат будет использован при показе дат в Kanban-карточках.',
   'Show relative date': 'Показывать относительную дату',
+  "When toggled, cards will display the distance between today and the card's date. eg. 'In 3 days', 'A month ago'. Relative dates will not be shown for dates from the Tasks and Dataview plugins.":
+    "Когда включено, карточки показывают расстояние между сегодняшним днём и датой карточки — например «Через 3 дня», «Месяц назад». Относительные даты не показываются для дат из плагинов Tasks и Dataview.",
+
+  'Move dates to card footer': 'Переместить даты в подвал карточки',
+  "When toggled, dates will be displayed in the card's footer instead of the card's body.":
+    'Когда включено, даты отображаются в подвале карточки, а не в её теле.',
+  'Move tags to card footer': 'Переместить метки в подвал карточки',
+  "When toggled, tags will be displayed in the card's footer instead of the card's body.":
+    'Когда включено, метки отображаются в подвале карточки, а не в её теле.',
+  'Move task data to card footer': 'Переместить данные задач в подвал карточки',
+  "When toggled, task data (from the Tasks plugin) will be displayed in the card's footer instead of the card's body.":
+    'Когда включено, данные задач (из плагина Tasks) отображаются в подвале карточки, а не в её теле.',
+  'Inline metadata position': 'Расположение встроенных метаданных',
+  'Controls where the inline metadata (from the Dataview plugin) will be displayed.':
+    'Определяет, где отображаются встроенные метаданные (из плагина Dataview).',
+  'Card body': 'Тело карточки',
+  'Card footer': 'Подвал карточки',
+  'Merge with linked page metadata': 'Объединить с метаданными связанной страницы',
+
   'Hide card counts in list titles': 'Скрыть счётчики карточек в заголовках списка',
   'When toggled, card counts are hidden from the list title':
     'Когда включено, счётчики карточек скрыты в заголовках списка',
@@ -106,9 +137,15 @@ const lang: Partial<Lang> = {
     'Будет использоваться для отделения даты/времени архивирования от заголовка',
   'Archive date/time format': 'Формат даты/времени архивирования',
   'Kanban Plugin': 'Плагин Kanban',
+  'Tag click action': 'Действие по клику на метку',
+  'Search Kanban Board': 'Искать по Kanban-доске',
+  'Search Obsidian Vault': 'Искать по хранилищу Obsidian',
+  'This setting controls whether clicking the tags displayed below the card title opens the Obsidian search or the Kanban board search.':
+    'Эта настройка определяет, открывает ли клик по меткам под заголовком карточки поиск Obsidian или поиск по Kanban-доске.',
   'Tag colors': 'Показывать цвета меток',
   'Set colors for tags displayed in cards.': 'Установить цвета для меток под заголовками карточек.',
   'Linked Page Metadata': 'Метаданные связанных страниц',
+  'Inline Metadata': 'Встроенные метаданные',
   'Display metadata for the first note linked within a card. Specify which metadata keys to display below. An optional label can be provided, and labels can be hidden altogether.':
     'Отображение метаданных для первой заметки, связанной с карточкой. Ниже укажите, какие ключи метаданных отображать. Можно указать дополнительную метку, либо скрыть метки полностью.',
   'Board Header Buttons': 'Кнопки заголовка доски',
@@ -137,19 +174,40 @@ const lang: Partial<Lang> = {
 
   // MetadataSettings.tsx
   'Metadata key': 'Ключ метаданных',
-  'Display label': 'Показать ярылк',
+  'Display label': 'Показать ярлык',
   'Hide label': 'Спрятать ярлык',
   'Drag to rearrange': 'Потяните, чтобы переупорядочить',
   Delete: 'Удалить',
   'Add key': 'Добавить ключ',
+  'Add tag': 'Добавить метку',
   'Field contains markdown': 'Поле содержит markdown',
+  'Tag sort order': 'Порядок сортировки меток',
+  'Set an explicit sort order for the specified tags.':
+    'Задать явный порядок сортировки для указанных меток.',
 
   // TagColorSettings.tsx
   'Add tag color': 'Добавить цвет метки',
 
+  // components/Table.tsx
+  List: 'Список',
+  Card: 'Карточка',
+  Date: 'Дата',
+  Tags: 'Метки',
+  Priority: 'Приоритет',
+  Start: 'Начало',
+  Created: 'Создано',
+  Scheduled: 'Запланировано',
+  Due: 'Срок',
+  Cancelled: 'Отменено',
+  Recurrence: 'Повторение',
+  'Depends on': 'Зависит от',
+  ID: 'ID',
+
   // components/Item/Item.tsx
   'More options': 'Больше настроек',
   Cancel: 'Отмена',
+  Done: 'Готово',
+  Save: 'Сохранить',
 
   // components/Item/ItemContent.tsx
   today: 'сегодня',
@@ -182,6 +240,7 @@ const lang: Partial<Lang> = {
   'Add label': 'Добавить ярлык',
   'Move to top': 'Переместить вверх',
   'Move to bottom': 'Переместить вниз',
+  'Move to list': 'Переместить в список',
 
   // components/Lane/LaneForm.tsx
   'Enter list title...': 'Введите заголовок списка...',
@@ -211,6 +270,8 @@ const lang: Partial<Lang> = {
   'Insert list after': 'Вставить список после',
   'Sort by card text': 'Сортировать по тексту карточки',
   'Sort by date': 'Сортировать по дате',
+  'Sort by tags': 'Сортировать по меткам',
+  'Sort by': 'Сортировать по',
 
   // components/helpers/renderMarkdown.ts
   'Unable to find': 'Невозможно найти',

--- a/src/settingHelpers.ts
+++ b/src/settingHelpers.ts
@@ -143,6 +143,134 @@ export function createSearchSelect({
           choices: list,
         }).setChoiceByValue('');
 
+        // [Kanban-DIAG] diagnostic logging — gated behind the "debug-logging" setting.
+        // Surfaces Choices.js / popout-window interactions that otherwise fail silently.
+        const debugOn = !!manager.getSetting('debug-logging', local)[0];
+        if (debugOn) {
+          const tag = '[Kanban-DIAG]';
+          const win = el.win as any;
+          const doc = (win as any).document ?? (manager as any).activeDocument ?? (globalThis as any).activeDocument;
+          const log = (...args: any[]) => {
+            try { (console as any).log(tag, ...args); } catch (_) {}
+          };
+
+          try {
+            const snapshot: Record<string, unknown> = {
+              key: String(key),
+              local,
+              listLen: list.length,
+              searchEnabled: list.length > 10,
+              value,
+              globalValue,
+              choicesApi: typeof c,
+              hasShowDropdown: typeof (c as any).showDropdown === 'function',
+              hasHideDropdown: typeof (c as any).hideDropdown === 'function',
+              hasDestroy: typeof (c as any).destroy === 'function',
+              isActiveWindow: typeof (win as any).activeDocument === 'object',
+              docIsWinDoc: doc === (win as any).document,
+              docIsGlobalDoc: doc === (globalThis as any).document,
+              docIsActiveDoc: doc === (globalThis as any).activeDocument,
+              containerInitial: !!(c as any).containerOuter,
+              inputInitial: !!(c as any).containerOuter?.input,
+            };
+            log('snapshot', snapshot);
+          } catch (e) {
+            log('snapshot-error', e);
+          }
+
+          // Intercept showDropdown / hideDropdown to log when they fire and what state they observe.
+          try {
+            const origShow = (c as any).showDropdown?.bind(c);
+            if (typeof origShow === 'function') {
+              (c as any).showDropdown = (...args: any[]) => {
+                let outer: any = null;
+                try { outer = (c as any).containerOuter?.element ?? null; } catch (_) {}
+                log('showDropdown() CALLED', {
+                  isOpenBefore: !!(c as any).currentState?.isOpen,
+                  containerInDom: outer ? !!(outer.getRootNode?.() as any) : false,
+                  outerClass: outer?.className ?? null,
+                });
+                return origShow(...args);
+              };
+            }
+            const origHide = (c as any).hideDropdown?.bind(c);
+            if (typeof origHide === 'function') {
+              (c as any).hideDropdown = (...args: any[]) => {
+                log('hideDropdown() CALLED');
+                return origHide(...args);
+              };
+            }
+          } catch (e) {
+            log('intercept-error', e);
+          }
+
+          // Poll the DOM a few times right after init — confirms container lands in the right document.
+          try {
+            const outerEl = (c as any).containerOuter?.element as HTMLElement | undefined;
+            let poll = 0;
+            const pollId = win.setInterval(() => {
+              poll += 1;
+              try {
+                log('poll', {
+                  n: poll,
+                  outerExists: !!outerEl,
+                  outerInDom: outerEl ? outerEl.isConnected : false,
+                  outerOwnerDocSameAsWin:
+                    outerEl && (win as any).document
+                      ? outerEl.ownerDocument === (win as any).document
+                      : null,
+                  hasChoicesOpen: !!doc?.querySelector?.('.choices.is-open'),
+                });
+              } catch (_) {}
+              if (poll >= 5) win.clearInterval(pollId);
+            }, 100);
+          } catch (e) {
+            log('poll-setup-error', e);
+          }
+
+          // Listen for click/show events directly on the choices container.
+          try {
+            const choicesContainer = (c as any).containerOuter?.element as HTMLElement | undefined;
+            if (choicesContainer) {
+              const evtNames = ['click', 'mousedown', 'keydown', 'focus'];
+              evtNames.forEach((evtName) => {
+                choicesContainer.addEventListener(evtName, (e: Event) => {
+                  log('container:' + evtName, {
+                    targetTag: (e.target as HTMLElement)?.tagName,
+                    targetClass: (e.target as HTMLElement)?.className,
+                  });
+                });
+              });
+              manager.cleanupFns.push(() => {
+                evtNames.forEach((evtName) => {
+                  choicesContainer.removeEventListener(evtName, null as any);
+                });
+              });
+            }
+          } catch (e) {
+            log('container-listener-error', e);
+          }
+
+          // Global click listener on the window's document — confirms which document
+          // receives the click when the dropdown is in a popout window.
+          try {
+            const onDocClick = (e: Event) => {
+              const outerEl = (c as any).containerOuter?.element as HTMLElement | undefined;
+              log('doc:click', {
+                targetTag: (e.target as HTMLElement)?.tagName,
+                containsOuter: outerEl ? outerEl.contains(e.target as Node) : 'no-outer',
+                activeElTag: (doc as any)?.activeElement?.tagName,
+              });
+            };
+            doc?.addEventListener?.('click', onDocClick, true);
+            manager.cleanupFns.push(() => {
+              doc?.removeEventListener?.('click', onDocClick, true);
+            });
+          } catch (e) {
+            log('doc-listener-error', e);
+          }
+        }
+
         if (value && typeof value === 'string' && list.findIndex((f) => f.value === value) > -1) {
           c.setChoiceByValue(value);
         }


### PR DESCRIPTION
…, add debug logging & full Russian locale

Fixes three issues and ships a complete Russian translation.

Popout-window dropdown fix (choices.js):
Choices.js 9.0.1 attaches its global click listener to `document.documentElement`, which in Obsidian v1.7+ popout windows is a different document than the one the dropdown element belongs to. The click landed on the wrong document, so `containerOuter.element.contains(target)` returned false and _onClick ran the hideDropdown() branch instead of showDropdown() — the Note folder dropdown never opened in popout windows. esbuild replace-plugin now rewrites `document` -> `activeDocument` and `window` -> `activeWindow` inside choices.js, routing the listener to the active window's document. Also applied to node_modules for setTimeout/etc.

Note folder path validation (#996):
In ItemMenu.ts, `getAbstractFileByPath(newNoteFolder)` was cast to TFolder without validation. A stale or invalid path silently broke note creation, dropping new notes in the vault root. Now validated with `instanceof TFolder` and falls back to `getNewFileParent()` when the configured folder is missing.

Debug logging (opt-in):
Added a "Debug logging" toggle in Settings -> Debug. When on, createSearchSelect emits [Kanban-DIAG] logs to the dev console (Choices snapshot, showDropdown / hideDropdown interception, DOM polling, container & document click listeners). Off by default; all listeners are cleaned up via cleanupFns. Helps troubleshoot the Note folder dropdown and other Choices.js / popout issues.

Russian locale (ru.ts):
Completed the Russian translation — all 166 keys now covered (was 149/166, 17 strings fell back to English). Added: View as board/list/table, Move dates/tags/task-data to card footer, Inline metadata position, Tag click action, Search Kanban Board/Vault, Expand lists, full Table.tsx columns, Done/Save, Move to list, Sort by tags/by, and Show relative date description. Fixed typos: "завершёённые" -> "завершённые", "ярылк" -> "ярлык".

Bump version 2.0.51 -> 2.0.52.