### PR TITLE
fix(lang): detect UI language via moment.locale() with fallback, complete zh-CN translation

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "clean": "yarn prettier && yarn lint:fix",
     "rlnotes": "git log $(git describe --tags --abbrev=0)..HEAD --oneline > release-notes.md && git add release-notes.md",
     "bump": "node version-bump.mjs && git add package.json manifest.json versions.json && yarn rlnotes",
-    "release": "git commit -m $npm_package_version && git tag $npm_package_version && git push && git push --tags"
+    "release": "git commit -m $npm_package_version && git tag $npm_package_version && git push && git push --tags",
+    "test": "node tests/lang.test.mjs"
   },
   "keywords": [],
   "author": "",

--- a/src/lang/helpers.ts
+++ b/src/lang/helpers.ts
@@ -1,3 +1,6 @@
+import { moment } from 'obsidian';
+
+import { buildLangNormalizer } from './normalizeLang';
 import ar from './locale/ar';
 import cz from './locale/cz';
 import da from './locale/da';
@@ -19,7 +22,7 @@ import ro from './locale/ro';
 import ru from './locale/ru';
 import sq from './locale/sq';
 import tr from './locale/tr';
-import uk from './locale/tr';
+import uk from './locale/uk';
 import zhCN from './locale/zh-cn';
 import zhTW from './locale/zh-tw';
 
@@ -50,8 +53,15 @@ const localeMap: { [k: string]: Partial<Lang> } = {
   zh: zhCN,
 };
 
-const lang = window.localStorage.getItem('language');
-const locale = localeMap[lang || 'en'];
+// 界面语言检测：moment.locale() 是 Obsidian 官方提供的入口，始终反映
+// 当前界面语言；localStorage 'language' 是旧版 Obsidian 的实现细节，
+// 仅部分版本写入，作为兜底保留。
+const normalizeLang = buildLangNormalizer(Object.keys(localeMap));
+const lang =
+  normalizeLang(moment.locale()) ??
+  normalizeLang(window.localStorage.getItem('language')) ??
+  'en';
+const locale = localeMap[lang];
 
 export function t(str: keyof typeof en): string {
   if (!locale) {

--- a/src/lang/locale/zh-cn.ts
+++ b/src/lang/locale/zh-cn.ts
@@ -14,6 +14,11 @@ const lang: Partial<Lang> = {
   'Untitled Kanban': '未命名看板',
   'Toggle between Kanban and markdown mode': '在看板和 Markdown 模式之间进行切换',
 
+  'View as board': '以看板视图查看',
+  'View as list': '以列表视图查看',
+  'View as table': '以表格视图查看',
+  'Board view': '看板视图',
+
   // KanbanView.tsx
   'Open as markdown': '打开为 Markdown 文件',
   'Open board settings': '打开看板设置',
@@ -86,7 +91,10 @@ const lang: Partial<Lang> = {
   'Date display format': '日期展示格式',
   'This format will be used when displaying dates in Kanban cards.': '看板卡片会以该格式展示日期。',
   'Show relative date': '展示相对日期',
+  "When toggled, cards will display the distance between today and the card's date. eg. 'In 3 days', 'A month ago'. Relative dates will not be shown for dates from the Tasks and Dataview plugins.":
+    '打开时，卡片将显示当前日期与卡片日期之间的距离，例如“3 天后”“一个月前”。来自 Tasks 和 Dataview 插件的日期不会显示相对日期。',
   'Hide card counts in list titles': '在列标题上隐藏卡片计数',
+  'Expand lists to full width in list view': '在列表视图中将列扩展至全宽',
   'When toggled, card counts are hidden from the list title': '打开时，列标题上的卡片计数将隐藏',
   'Link dates to daily notes': '链接日期到日记',
   'When toggled, dates will link to daily notes. Eg. [[2021-04-26]]':
@@ -94,12 +102,31 @@ const lang: Partial<Lang> = {
   'Add date and time to archived cards': '添加日期和时间到归档卡片',
   'When toggled, the current date and time will be added to the card title when it is archived. Eg. - [ ] 2021-05-14 10:00am My card title':
     '打开时，当前日期和时间会被添加到归档卡片的 frontmatter 上，例如“- [ ] 2021-05-14 10:00am 我的卡片标题”',
-  'Archive date/time separator': '归档日期或时间分隔符Archive date/time separator',
+  'Move dates to card footer': '将日期移至卡片页脚',
+  "When toggled, dates will be displayed in the card's footer instead of the card's body.":
+    '打开时，日期将显示在卡片页脚而不是卡片正文中。',
+  'Move tags to card footer': '将标签移至卡片页脚',
+  "When toggled, tags will be displayed in the card's footer instead of the card's body.":
+    '打开时，标签将显示在卡片页脚而不是卡片正文中。',
+  'Move task data to card footer': '将任务数据移至卡片页脚',
+  "When toggled, task data (from the Tasks plugin) will be displayed in the card's footer instead of the card's body.":
+    '打开时，任务数据（来自 Tasks 插件）将显示在卡片页脚而不是卡片正文中。',
+  'Archive date/time separator': '归档日期/时间分隔符',
   'This will be used to separate the archived date/time from the title':
     '用于分隔标题与归档卡片的日期或时间',
   'Archive date/time format': '归档日期或时间格式',
+  'Add archive date/time after card title': '在卡片标题后添加归档日期/时间',
+  'When toggled, the archived date/time will be added after the card title, e.g.- [ ] My card title 2021-05-14 10:00am. By default, it is inserted before the title.':
+    '打开时，归档日期/时间将添加到卡片标题之后，例如 - [ ] 我的卡片标题 2021-05-14 10:00am。默认插入在标题之前。',
   'Kanban Plugin': '看板插件',
   'Linked Page Metadata': '连接的页面元数据',
+  'Inline Metadata': '内联元数据',
+  'Inline metadata position': '内联元数据位置',
+  'Controls where the inline metadata (from the Dataview plugin) will be displayed.':
+    '控制内联元数据（来自 Dataview 插件）的显示位置。',
+  'Card body': '卡片正文',
+  'Card footer': '卡片页脚',
+  'Merge with linked page metadata': '与连接的页面元数据合并',
   'Display metadata for the first note linked within a card. Specify which metadata keys to display below. An optional label can be provided, and labels can be hidden altogether.':
     '展示卡片中第一个连接所对应的笔记元数据。请在下方指定哪些元数据可以展示。你可以选择展示哪些标志，所有标志都可以被隐藏。',
   'Board Header Buttons': '板头按钮',
@@ -113,6 +140,52 @@ const lang: Partial<Lang> = {
   Friday: '周五',
   Saturday: '周六',
 
+  // TagColorSettings / TagSortSettings
+  'Tag click action': '标签点击行为',
+  'This setting controls whether clicking the tags displayed below the card title opens the Obsidian search or the Kanban board search.':
+    '该设置控制点击卡片标题下方标签时，打开的是 Obsidian 搜索还是看板搜索。',
+  'Search Kanban Board': '搜索看板',
+  'Search Obsidian Vault': '搜索 Obsidian 仓库',
+  'Tag colors': '标签颜色',
+  'Set colors for tags displayed in cards.': '设置卡片中标签的颜色。',
+  'Add tag': '添加标签',
+  'Add tag color': '添加标签颜色',
+  'Background color': '背景颜色',
+  'Text color': '文字颜色',
+  'Tag sort order': '标签排序',
+  'Set an explicit sort order for the specified tags.': '为指定标签设置明确的排序。',
+  'Sort by tags': '以标签排序',
+  'Sort by': '排序方式',
+
+  // DateColorSettings
+  'Tag': '标签',
+  'Tags': '标签',
+  'Date is': '日期为',
+  'Today': '今天',
+  'Before now': '现在之前',
+  'After now': '现在之后',
+  'Between now and': '介于现在与……之间',
+  'Display date colors': '显示日期颜色',
+  'Set colors for dates displayed in cards based on the rules below.':
+    '按照下方规则设置卡片中日期的颜色。',
+  'Add date color': '添加日期颜色',
+
+  // 表格视图列头与任务字段
+  'Card': '卡片',
+  'List': '列',
+  'Date': '日期',
+  'Priority': '优先级',
+  'Start': '开始',
+  'Created': '创建',
+  'Scheduled': '计划',
+  'Due': '截止',
+  'Cancelled': '已取消',
+  'Recurrence': '重复',
+  'Depends on': '依赖于',
+  'ID': 'ID',
+  'Done': '完成',
+  'Save': '保存',
+
   // MetadataSettings.tsx
   'Metadata key': '元数据参数名',
   'Display label': '展示标志',
@@ -120,6 +193,7 @@ const lang: Partial<Lang> = {
   'Drag to rearrange': '拖动以重排顺序',
   Delete: '删除',
   'Add key': '添加参数名',
+  'Add label': '添加标志',
   'Field contains markdown': '字段包含 Markdown',
 
   // components/Item/Item.tsx
@@ -156,6 +230,7 @@ const lang: Partial<Lang> = {
   'Insert card after': '在下方插入卡片',
   'Move to top': '移到顶部',
   'Move to bottom': '移至底部',
+  'Move to list': '移动到列',
 
   // components/Lane/LaneForm.tsx
   'Enter list title...': '输入新的列标题……',

--- a/src/lang/normalizeLang.ts
+++ b/src/lang/normalizeLang.ts
@@ -1,0 +1,44 @@
+// 将任意语言标识（moment.locale() 或 localStorage 中的值）归一化到
+// localeMap 的某个键，未匹配时返回 null。
+// moment.locale() 返回 'zh-cn'、'zh-tw'、'en' 这类小写形式；
+// localStorage 'language' 键返回 'zh'、'en-gb' 这类形式。
+
+// 脚本变体别名：moment/Obsidian 不使用这些值，但用户环境可能传来
+const ALIASES: Record<string, string> = {
+  'zh-hans': 'zh-cn',
+  'zh-sg': 'zh-cn',
+  'zh-hant': 'zh-tw',
+  'zh-hk': 'zh-tw',
+  'zh-mo': 'zh-tw',
+};
+
+export function buildLangNormalizer(
+  availableKeys: readonly string[]
+): (raw: string | null | undefined) => string | null {
+  // 精确表：键的小写形式 -> 原键（'zh-tw' -> 'zh-TW'）
+  const exact = new Map<string, string>();
+  // 前缀表：主语言代码 -> 默认键（'zh' -> 'zh'，'en' -> 'en'）
+  const prefix = new Map<string, string>();
+
+  for (const key of availableKeys) {
+    const lower = key.toLowerCase();
+    if (!exact.has(lower)) exact.set(lower, key);
+  }
+  // 先由不带区域的裸键建立前缀默认，避免 'zh-TW' 之类区域键反向覆盖 'zh'
+  for (const key of availableKeys) {
+    const lower = key.toLowerCase();
+    if (!lower.includes('-')) prefix.set(lower, key);
+  }
+  // 某语言只有区域键时（如仅有 pt-BR），用区域键补上该前缀
+  for (const key of availableKeys) {
+    const p = key.toLowerCase().split('-')[0];
+    if (!prefix.has(p)) prefix.set(p, key);
+  }
+
+  return (raw) => {
+    if (!raw) return null;
+    const aliased = ALIASES[raw.toLowerCase()] ?? raw;
+    const lower = aliased.toLowerCase();
+    return exact.get(lower) ?? prefix.get(lower.split('-')[0]) ?? null;
+  };
+}

--- a/tests/lang.test.mjs
+++ b/tests/lang.test.mjs
@@ -1,0 +1,127 @@
+// 语言模块契约测试：
+// 1. normalizeLang 归一化契约（esbuild 编译纯函数后断言）
+// 2. 翻译完整性契约（各语言文件键必须 ⊆ en.ts 键；zh-cn.ts 必须全覆盖）
+// 运行：npm test（node tests/lang.test.mjs）
+import { build } from 'esbuild';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+let failed = 0;
+const tests = [];
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+// ---------- 1. normalizeLang 契约 ----------
+
+const LOCALE_KEYS = [
+  'ar', 'cz', 'da', 'de', 'en', 'es', 'fr', 'hi', 'id', 'it', 'ja', 'ko',
+  'nl', 'no', 'pl', 'pt', 'pt-BR', 'ro', 'ru', 'sq', 'tr', 'uk', 'zh', 'zh-TW',
+];
+
+const outDir = mkdtempSync(join(tmpdir(), 'kanban-lang-test-'));
+await build({
+  entryPoints: ['src/lang/normalizeLang.ts'],
+  bundle: true,
+  format: 'esm',
+  outfile: join(outDir, 'normalizeLang.mjs'),
+  logLevel: 'silent',
+});
+const { buildLangNormalizer } = await import(
+  pathToFileURL(join(outDir, 'normalizeLang.mjs'))
+);
+const normalize = buildLangNormalizer(LOCALE_KEYS);
+
+const cases = [
+  // 简中：裸键与各种区域/别名形式都归一到 zh
+  ['zh', 'zh'],
+  ['zh-cn', 'zh'],
+  ['zh-CN', 'zh'],
+  ['zh-hans', 'zh'],
+  ['zh-sg', 'zh'],
+  // 繁中：精确与别名归一到 zh-TW
+  ['zh-TW', 'zh-TW'],
+  ['zh-tw', 'zh-TW'],
+  ['zh-hant', 'zh-TW'],
+  ['zh-hk', 'zh-TW'],
+  // 英语：区域后缀回落裸键
+  ['en', 'en'],
+  ['en-gb', 'en'],
+  ['en-US', 'en'],
+  // 葡语：区域精确命中
+  ['pt', 'pt'],
+  ['pt-br', 'pt-BR'],
+  ['pt-BR', 'pt-BR'],
+  // 大小写不敏感
+  ['DE', 'de'],
+  ['ja', 'ja'],
+  // 未知语言 / 空值
+  ['xx', null],
+  ['sr-Latn', null],
+  ['', null],
+  [null, null],
+  [undefined, null],
+];
+
+for (const [input, expected] of cases) {
+  test(`normalize(${JSON.stringify(input)}) === ${JSON.stringify(expected)}`, () => {
+    assert.equal(normalize(input), expected);
+  });
+}
+
+// ---------- 2. 翻译完整性契约 ----------
+
+const LOCALE_DIR = 'src/lang/locale';
+
+function extractKeys(path) {
+  const keys = new Set();
+  const lines = readFileSync(path, 'utf-8').split(/\r?\n/);
+  for (let line of lines) {
+    line = line.trim();
+    if (line.startsWith('//') || line.startsWith('*')) continue;
+    let m = line.match(/^'([^']+)':/) || line.match(/^"([^"]+)":/);
+    if (m) {
+      keys.add(m[1]);
+      continue;
+    }
+    m = line.match(/^([A-Za-z_$][A-Za-z0-9_$]*):/);
+    if (m) keys.add(m[1]);
+  }
+  return keys;
+}
+
+const enKeys = extractKeys(join(LOCALE_DIR, 'en.ts'));
+
+const localeFiles = readdirSync(LOCALE_DIR).filter(
+  (f) => f.endsWith('.ts') && f !== 'en.ts'
+);
+for (const file of localeFiles) {
+  const keys = extractKeys(join(LOCALE_DIR, file));
+  const extra = [...keys].filter((k) => !enKeys.has(k));
+  test(`${file} 不含 en.ts 之外的键`, () => {
+    assert.deepEqual(extra, [], `多余键: ${extra.join(', ')}`);
+  });
+}
+
+test('zh-cn.ts 覆盖 en.ts 全部键（缺失数为 0）', () => {
+  const zhKeys = extractKeys(join(LOCALE_DIR, 'zh-cn.ts'));
+  const missing = [...enKeys].filter((k) => !zhKeys.has(k));
+  assert.deepEqual(missing, [], `缺失 ${missing.length} 个键`);
+});
+
+// ---------- 运行 ----------
+
+for (const { name, fn } of tests) {
+  try {
+    await fn();
+    console.log(`  ok  ${name}`);
+  } catch (e) {
+    failed++;
+    console.error(`FAIL  ${name}\n      ${e.message}`);
+  }
+}
+console.log(`\n${tests.length - failed}/${tests.length} 通过`);
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
## Problem

The plugin detects the interface language solely via `localStorage.getItem('language')`. Newer Obsidian versions no longer write this key, so on affected installations the plugin silently falls back to English even though the Obsidian UI is set to another language (verified on Obsidian 2.1.3 with UI language `zh`: the key is absent from the app's localStorage).

Related: #368 (request to override detected language), #106 (`locale not found en-gb`).

## Changes

**Language detection (`src/lang/helpers.ts` + new `src/lang/normalizeLang.ts`)**
- Prefer `moment.locale()` (the official API, always reflects the current UI language); keep the legacy `localStorage` key as a fallback only.
- New pure function `buildLangNormalizer(availableKeys)` normalizes any identifier (e.g. `zh-cn`, `zh-TW`, `en-gb`, `pt-br`, aliases `zh-hant`/`zh-hk`/`zh-sg`) to an existing `localeMap` key, or `null`. Region-suffixed keys never shadow the bare-language key (`zh-TW` does not override `zh`).
- Fixes a pre-existing typo: the `uk` locale was imported from `./locale/tr` (both are empty stubs, so no behavior change).

**zh-CN completion (`src/lang/locale/zh-cn.ts`)**
- Coverage 140 -> 200 keys (100% of `en.ts`): table-view column headers, tag/date color settings, card footer settings, Tasks/Dataview field names, etc. Terminology follows the existing glossary.
- Fixes a mixed-language string: `'Archive date/time separator'` value had the English source appended to the Chinese translation.
- Keys containing apostrophes are double-quoted to match the style used in `en.ts`.

**Tests (`tests/lang.test.mjs`, wired as `npm test`)**
- Contract tests for the normalizer (zh/zh-cn/zh-TW/en-gb/pt-br/aliases/unknown/null cases).
- Integrity assertions for every locale file: keys must be a subset of `en.ts`, and `zh-cn.ts` must cover all `en.ts` keys.

## Verification

- `npm test`: 46/46 pass.
- `tsc --noemit`: the 41 errors on this branch are pre-existing on `main` as well (unrelated `Cannot find name 'app'` in parser files).
- Built and installed locally; UI now renders in Chinese on Obsidian 2.1.3 where the plugin previously fell back to English.